### PR TITLE
Fix grad_log_utility sign handling

### DIFF
--- a/riemannian_portfolio/objectives.py
+++ b/riemannian_portfolio/objectives.py
@@ -7,5 +7,7 @@ _EPS = 1e-12
 def grad_log_utility(mu: np.ndarray, w: np.ndarray) -> np.ndarray:
     mu = np.asarray(mu, dtype=float)
     w = np.asarray(w, dtype=float)
-    denom = max(float(w @ mu), 1e-6)
-    return mu / denom
+    denom = float(w @ mu)
+    scale = max(abs(denom), _EPS)
+    denom_safe = np.copysign(scale, denom if denom != 0 else 1.0)
+    return mu / denom_safe

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -1,0 +1,20 @@
+import numpy as np
+from riemannian_portfolio.objectives import grad_log_utility
+
+
+def test_grad_log_utility_matches_formula():
+    mu = np.array([0.02, 0.01, -0.03])
+    w = np.array([0.4, 0.3, 0.3])
+    expected = mu / (w @ mu)
+    got = grad_log_utility(mu, w)
+    assert np.allclose(got, expected)
+
+
+def test_grad_log_utility_handles_negative_denominator():
+    mu = np.array([-0.04, -0.01, -0.02])
+    w = np.array([0.2, 0.5, 0.3])
+    denom = w @ mu
+    assert denom < 0
+    grad = grad_log_utility(mu, w)
+    expected = mu / denom
+    assert np.allclose(grad, expected)


### PR DESCRIPTION
## Summary
- preserve the sign of the expected return when computing `grad_log_utility`
- add unit tests that exercise positive and negative expected return scenarios

## Testing
- PYTHONPATH=. pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e6358b0bf88333ba476501ce28ae76