### PR TITLE
Fix overflow handling in natural mirror step

### DIFF
--- a/riemannian_portfolio/core/optim_ng_eg.py
+++ b/riemannian_portfolio/core/optim_ng_eg.py
@@ -34,10 +34,20 @@ def natural_mirror_step(
     else:
         step = eta * inv_precond * grad
 
+    step = np.asarray(step, dtype=float)
+    step -= np.max(step)
+
     z = w * np.exp(step)
     z_sum = z.sum()
+
+    if not np.isfinite(z_sum) or z_sum <= _EPS:
+        step = np.clip(step, -700.0, 700.0)
+        z = w * np.exp(step)
+        z_sum = z.sum()
+
     if not np.isfinite(z_sum) or z_sum <= _EPS:
         z = w + 1e-4 * grad
+
     z = np.clip(z, _EPS, None)
     z /= z.sum()
     return z


### PR DESCRIPTION
## Summary
- stabilize the natural mirror step by normalizing the exponent and clipping extreme updates
- retain a fallback path when the update remains numerically unstable

## Testing
- `python -m riemannian_portfolio.eval.ablation --seeds 101 202 303 404 505`


------
https://chatgpt.com/codex/tasks/task_e_68e63afdb98c8333867b1e2ca9941d74