### PR TITLE
Add KL trust-region natural-gradient step and ablation harness updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 
-# Riemannian Portfolio Flow (v0.2.0)
+# Riemannian Portfolio Flow (v0.2.1)
 
-Natural‑gradient mirror descent on the portfolio simplex with an Empirical Fisher preconditioner (Normal model pullback) and transaction‑cost‑aware execution via no‑trade bands. Includes robust μ/Σ estimators, a minimal backtester, and a **baseline ablation harness**.
+Natural-gradient mirror descent on the portfolio simplex with an Empirical Fisher preconditioner (Normal model pullback) and transaction-cost-aware execution via no-trade bands. Includes robust μ/Σ estimators, a minimal backtester, and a **baseline ablation harness**.
 
-## What's new in v0.2.0
-- **Ablation harness** comparing **NG‑EG**, **EG (no Fisher)**, and **Buy‑and‑Hold** across seeds with **net‑of‑costs**.
-- **CLI knobs:** `--eta`, `--delta-in`, `--delta-out`, `--T`, `--n`, `--window`, `--cost-bps`, `--seeds`.
-- Plotting remains optional/lazy.
+## What's new in v0.2.1
+- **KL trust-region** update: constrain step size via `KL(w_prev || w_step) ≤ --kl-step` for stability and fair comparisons.
+- **Fisher normalization**: per-step median normalization of the inverse Fisher to avoid scale pathologies.
+- **Expanded ablation harness**: compare **NG-EG**, **EG (no Fisher)**, and **Buy-and-Hold** with **net-of-costs** metrics.
+- **CLI knobs**: `--eta-eg/--eta-ng`, `--kl-step`, `--cost-bps`, alongside existing controls.
 
 ## Quick start
 ```bash
 pytest -q
-python -m riemannian_portfolio.eval.backtest --seed 7 --T 800 --n 10 --eta 0.5 --delta-in 1e-4 --delta-out 5e-4
-python -m riemannian_portfolio.eval.ablation --T 800 --n 10 --seeds 7 11 13 17 --cost-bps 5
+python -m riemannian_portfolio.eval.backtest --seed 7 --T 800 --n 10 --eta 0.5 --delta-in 1e-4 --delta-out 5e-4 --kl-step 2e-4
+python -m riemannian_portfolio.eval.ablation --T 800 --n 10 --seeds 7 11 13 17 19 --cost-bps 10 --kl-step 2e-4 --eta-eg 0.4 --eta-ng 0.4
 ```
 
 ## Optional plotting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "riemannian-portfolio"
-version = "0.2.0"
-description = "Riemannian Portfolio Flow: NG Mirror Descent with Fisher pullback, no-trade execution, and ablation harness"
+version = "0.2.1"
+description = "Riemannian Portfolio Flow: NG Mirror Descent with Fisher pullback, no-trade execution, ablation harness, and KL trust region"
 readme = "README.md"
 requires-python = ">=3.9"
 authors = [{name = "Aether & S.C. Saridakis"}]

--- a/riemannian_portfolio/__init__.py
+++ b/riemannian_portfolio/__init__.py
@@ -1,10 +1,11 @@
 
-from .core.optim_ng_eg import natural_mirror_step, project_to_simplex
+from .core.optim_ng_eg import natural_mirror_step, project_to_simplex, natural_mirror_step_trust
 from .core.fisher import empirical_fisher_diag
 from .core.bands import kl_divergence, no_trade_policy
 
 __all__ = [
     "natural_mirror_step",
+    "natural_mirror_step_trust",
     "project_to_simplex",
     "empirical_fisher_diag",
     "kl_divergence",

--- a/riemannian_portfolio/eval/ablation.py
+++ b/riemannian_portfolio/eval/ablation.py
@@ -1,38 +1,44 @@
-
 from __future__ import annotations
 import argparse
 import numpy as np
 import pandas as pd
 
 from .backtest import synthetic_prices
-from ..core.optim_ng_eg import natural_mirror_step
+from ..core.optim_ng_eg import natural_mirror_step_trust
 from ..core.fisher import empirical_fisher_diag
 from ..core.bands import no_trade_policy
 from ..models.estimators import EWMA
 from ..objectives import grad_log_utility
 
-_EPS = 1e-12
 
-def run_strategy(kind: str, rets: np.ndarray, eta: float, delta_in: float, delta_out: float, window: int, cost_bps: float):
+def run_strategy(
+    kind: str,
+    rets: np.ndarray,
+    eta: float,
+    delta_in: float,
+    delta_out: float,
+    window: int,
+    cost_bps: float,
+    kl_step: float,
+):
     n = rets.shape[1]
     est = EWMA(alpha_mu=0.05, alpha_cov=0.05)
     w = np.ones(n) / n
     wealth = 1.0
     wealth_series = []
     turnovers = []
-    roll = []
+    roll: list[np.ndarray] = []
 
     for t in range(rets.shape[0]):
         x = rets[t]
         mu, Sigma = est.update(x)
 
         if kind == "bh":
-            w_new = w  # fixed initial uniform; no trades
+            w_new = w
         else:
             g = grad_log_utility(mu, w)
-
             if kind == "eg":
-                invF = 1.0  # no Fisher preconditioning
+                invF: float | np.ndarray = 1.0
             elif kind == "ng":
                 roll.append(x)
                 if len(roll) > window:
@@ -41,17 +47,15 @@ def run_strategy(kind: str, rets: np.ndarray, eta: float, delta_in: float, delta
                 diagF = empirical_fisher_diag(w, samples, mu, Sigma)
                 invF = 1.0 / np.maximum(diagF, 1e-8)
             else:
-                raise ValueError("unknown kind")
-
-            w_prop = natural_mirror_step(w, g, invF, eta)
+                raise ValueError(f"unknown kind: {kind}")
+            w_prop = natural_mirror_step_trust(w, g, invF, eta, kl_step=kl_step)
             w_new = no_trade_policy(w, w_prop, delta_in, delta_out)
 
         r_p = float(w @ x)
-        wealth *= (1.0 + r_p)
-        # proportional cost paid on trade size (half L1 norm)
+        wealth *= 1.0 + r_p
         turnover = 0.5 * float(np.abs(w_new - w).sum())
         cost = (cost_bps / 10000.0) * turnover
-        wealth *= (1.0 - cost)
+        wealth *= 1.0 - cost
 
         turnovers.append(turnover)
         wealth_series.append(wealth)
@@ -59,9 +63,9 @@ def run_strategy(kind: str, rets: np.ndarray, eta: float, delta_in: float, delta
 
     return pd.DataFrame({"wealth": wealth_series, "turnover": turnovers})
 
+
 def summarize(df: pd.DataFrame):
     ret = df["wealth"].to_numpy()
-    # simple daily returns from wealth
     rw = np.diff(np.r_[1.0, ret])
     mu = float(np.mean(rw))
     sd = float(np.std(rw) + 1e-12)
@@ -72,36 +76,76 @@ def summarize(df: pd.DataFrame):
         "net_sharpe": sharpe,
     }
 
-def run_ablation(T=800, n=10, seeds=(7,11,13), eta=0.5, delta_in=1e-4, delta_out=5e-4, window=64, cost_bps=5.0):
+
+def run_ablation(
+    T: int = 800,
+    n: int = 10,
+    seeds: tuple[int, ...] = (7, 11, 13),
+    eta_eg: float = 0.4,
+    eta_ng: float = 0.4,
+    delta_in: float = 1e-4,
+    delta_out: float = 5e-4,
+    window: int = 64,
+    cost_bps: float = 10.0,
+    kl_step: float = 2e-4,
+    eta: float | None = None,
+):
+    if eta is not None:
+        eta_eg = eta_ng = eta
     rows = []
     for seed in seeds:
         prices = synthetic_prices(T=T, n=n, seed=seed)
         rets = prices.pct_change().dropna().to_numpy()
-
-        for kind in ["bh", "eg", "ng"]:
-            res = run_strategy(kind, rets, eta, delta_in, delta_out, window, cost_bps)
-            s = summarize(res)
-            s.update({"seed": seed, "kind": kind})
-            rows.append(s)
+        for kind, eta in [("bh", 0.0), ("eg", eta_eg), ("ng", eta_ng)]:
+            res = run_strategy(
+                kind,
+                rets,
+                eta,
+                delta_in,
+                delta_out,
+                window,
+                cost_bps,
+                kl_step,
+            )
+            summary = summarize(res)
+            summary.update({"seed": seed, "kind": kind})
+            rows.append(summary)
     return pd.DataFrame(rows)
 
-def main():
-    p = argparse.ArgumentParser()
-    p.add_argument("--T", type=int, default=800)
-    p.add_argument("--n", type=int, default=10)
-    p.add_argument("--seeds", type=int, nargs="+", default=[7,11,13,17,19])
-    p.add_argument("--eta", type=float, default=0.5)
-    p.add_argument("--delta-in", type=float, default=1e-4, dest="delta_in")
-    p.add_argument("--delta-out", type=float, default=5e-4, dest="delta_out")
-    p.add_argument("--window", type=int, default=64)
-    p.add_argument("--cost-bps", type=float, default=5.0)
-    args = p.parse_args()
 
-    df = run_ablation(T=args.T, n=args.n, seeds=tuple(args.seeds), eta=args.eta,
-                      delta_in=args.delta_in, delta_out=args.delta_out, window=args.window, cost_bps=args.cost_bps)
-    # Pretty print grouped medians (seed-robust view)
-    summary = df.groupby("kind").median(numeric_only=True).reset_index()[["kind","final_wealth","mean_turnover","net_sharpe"]]
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--T", type=int, default=800)
+    parser.add_argument("--n", type=int, default=10)
+    parser.add_argument("--seeds", type=int, nargs="+", default=[7, 11, 13, 17, 19])
+    parser.add_argument("--eta-eg", type=float, default=0.4, dest="eta_eg")
+    parser.add_argument("--eta-ng", type=float, default=0.4, dest="eta_ng")
+    parser.add_argument("--delta-in", type=float, default=1e-4, dest="delta_in")
+    parser.add_argument("--delta-out", type=float, default=5e-4, dest="delta_out")
+    parser.add_argument("--window", type=int, default=64)
+    parser.add_argument("--cost-bps", type=float, default=10.0)
+    parser.add_argument("--kl-step", type=float, default=2e-4)
+    args = parser.parse_args()
+
+    df = run_ablation(
+        T=args.T,
+        n=args.n,
+        seeds=tuple(args.seeds),
+        eta_eg=args.eta_eg,
+        eta_ng=args.eta_ng,
+        delta_in=args.delta_in,
+        delta_out=args.delta_out,
+        window=args.window,
+        cost_bps=args.cost_bps,
+        kl_step=args.kl_step,
+    )
+    summary = (
+        df.groupby("kind").median(numeric_only=True).reset_index()[
+            ["kind", "final_wealth", "mean_turnover", "net_sharpe"]
+        ]
+    )
     print(summary.to_string(index=False))
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_trust_region.py
+++ b/tests/test_trust_region.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+from riemannian_portfolio.core.optim_ng_eg import natural_mirror_step_trust
+from riemannian_portfolio.core.bands import kl_divergence
+
+
+def test_trust_region_limits_kl():
+    w = np.array([0.3, 0.4, 0.3])
+    grad = np.array([0.5, -0.2, -0.1])
+    invF = np.array([2.0, 1.0, 0.5])
+    z = natural_mirror_step_trust(w, grad, invF, eta=1.0, kl_step=1e-4)
+    assert kl_divergence(w, z) <= 1.0001e-4
+    assert np.isclose(z.sum(), 1.0)
+    assert np.all(z >= 0)


### PR DESCRIPTION
## Summary
- add a KL-constrained natural-gradient EG step with Fisher normalization and export it from the package
- extend the backtest and ablation CLIs with KL trust-region controls and document the new capabilities
- bump the project version/readme and add a regression test covering the new trust-region step

## Testing
- PYTHONPATH=$PWD pytest

------
https://chatgpt.com/codex/tasks/task_e_68e6432bdbdc83338e7fd8b5b5a91105