### PR TITLE
Add guardrail for incompatible KL step and trading band parameters

### DIFF
--- a/riemannian_portfolio/eval/ablation.py
+++ b/riemannian_portfolio/eval/ablation.py
@@ -21,6 +21,12 @@ def run_strategy(
     cost_bps: float,
     kl_step: float,
 ):
+    if kl_step <= delta_in:
+        raise ValueError(
+            "The KL trust-region step must be larger than the inner no-trade band. "
+            "Otherwise every proposal stays inside the band and no trades occur. "
+            "Increase `--kl-step` or decrease `--delta-in`."
+        )
     n = rets.shape[1]
     est = EWMA(alpha_mu=0.05, alpha_cov=0.05)
     w = np.ones(n) / n

--- a/tests/test_ablation_params.py
+++ b/tests/test_ablation_params.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from riemannian_portfolio.eval.ablation import run_strategy
+
+
+def test_run_strategy_raises_when_kl_step_inside_band():
+    rets = np.random.default_rng(0).normal(size=(5, 3)) * 1e-3
+    with pytest.raises(ValueError):
+        run_strategy(
+            kind="eg",
+            rets=rets,
+            eta=0.1,
+            delta_in=2e-4,
+            delta_out=8e-4,
+            window=4,
+            cost_bps=10.0,
+            kl_step=1e-4,
+        )


### PR DESCRIPTION
## Summary
- raise a clear ValueError when the KL trust-region step is configured smaller than the inner no-trade band, which prevents any trading
- add a regression test ensuring the guardrail triggers for incompatible ablation parameters

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68e65b3882a88333a174c44325eee17a